### PR TITLE
The start.game supports relative paths and auto disable e-cores of Intel processors.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -3,6 +3,30 @@
 #include <stdio.h>
 #include <windows.h>
 #include "sider.h"
+#include <tlhelp32.h>
+#include <string.h>
+#include <stdlib.h>
+
+
+typedef struct {
+    DWORD processId;
+    wchar_t processName[MAX_PATH];
+} ProcessInfo;
+
+typedef struct {
+    DWORD pCoreCount;      
+    DWORD eCoreCount;      
+    DWORD_PTR pCoreMask;   
+    DWORD_PTR eCoreMask;   
+    DWORD totalCores;      
+    BOOL isHybrid;         
+} CPUCoreInfo;
+
+int FindAllProcessesByName(const wchar_t* processName, ProcessInfo* processes, int maxCount);
+BOOL SetProcessAffinityToPCores(DWORD processId, const CPUCoreInfo* coreInfo);
+BOOL IsIntelCPUWithECores();
+BOOL GetRealCoreInfo(CPUCoreInfo* coreInfo);
+int SetProcessesToPCores(const wchar_t* processName);
 
 
 HMODULE dll;
@@ -132,15 +156,26 @@ int APIENTRY WinMain(HINSTANCE hInstance,
     // launch game, if specified in config
     wstring start_game;
     wstring work_dir;
+    wstring process_name;
     if (get_start_game(start_game)) {
         applog_(L"start.game: %s\n", start_game.c_str());
-        int pos = start_game.rfind(L"\\");
-        if (pos != string::npos) {
-            work_dir = start_game.substr(0, pos);
-            applog_(L"working directory: %s\n", work_dir.c_str());
+        wchar_t absolute_path[MAX_PATH];
+        if (GetFullPathName(start_game.c_str(), MAX_PATH, absolute_path, NULL)) {
+            wstring abs_game_path = absolute_path;
+            
+            int pos = abs_game_path.rfind(L"\\");
+            if (pos != wstring::npos) {
+                work_dir = abs_game_path.substr(0, pos);
+                process_name = abs_game_path.substr(pos+1);
+                applog_(L"working directory: %s\n", work_dir.c_str());
+            }
+            ShellExecute(NULL, L"open", abs_game_path.c_str(), 0, work_dir.c_str(), SW_SHOWNORMAL);
         }
-        ShellExecute(NULL,L"open",start_game.c_str(),0,work_dir.c_str(),SW_SHOWNORMAL);
     }
+
+
+    int result = SetProcessesToPCores(process_name.c_str());
+    applog_(L"Set processes to PCores: %d\n", result);  
 
     //SetPriorityClass(GetCurrentProcess(), IDLE_PRIORITY_CLASS);
     while((retval = GetMessage(&msg,NULL,0,0)) != 0)
@@ -170,4 +205,203 @@ int init()
     setHook();
     applog_(L"Main: Init DONE\n");
 	return 0;
+}
+
+int SetProcessesToPCores(const wchar_t* processName) {
+    if (!IsIntelCPUWithECores()) {
+        return -1; 
+    }
+    
+    CPUCoreInfo coreInfo;
+    if (!GetRealCoreInfo(&coreInfo)) {
+        return -4; 
+    }
+    
+    if (!coreInfo.isHybrid) {
+        return -1;
+    }
+
+    
+    ProcessInfo processes[100];
+    int foundCount = FindAllProcessesByName(processName, processes, 100);
+    
+    if (foundCount == 0) {
+        return -2; 
+    }
+    
+    int failCount = 0;
+    for (int i = 0; i < foundCount; i++) {
+        if (!SetProcessAffinityToPCores(processes[i].processId, &coreInfo)) {
+            failCount++;
+        }
+    }
+    
+    return failCount;
+}
+
+
+int FindAllProcessesByName(const wchar_t* processName, ProcessInfo* processes, int maxCount) {
+    HANDLE hSnapshot;
+    PROCESSENTRY32W pe32;
+    int foundCount = 0;
+    
+    hSnapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+    if (hSnapshot == INVALID_HANDLE_VALUE) {
+        return 0;
+    }
+    
+    pe32.dwSize = sizeof(PROCESSENTRY32W);
+    
+    if (!Process32FirstW(hSnapshot, &pe32)) {
+        CloseHandle(hSnapshot);
+        return 0;
+    }
+    
+    do {
+        if (_wcsicmp(pe32.szExeFile, processName) == 0) {
+            if (foundCount < maxCount) {
+                processes[foundCount].processId = pe32.th32ProcessID;
+                wcscpy_s(processes[foundCount].processName, MAX_PATH, pe32.szExeFile);
+                foundCount++;
+            } else {
+                break; 
+            }
+        }
+    } while (Process32NextW(hSnapshot, &pe32));
+    
+    CloseHandle(hSnapshot);
+    return foundCount;
+}
+
+BOOL SetProcessAffinityToPCores(DWORD processId, const CPUCoreInfo* coreInfo) {
+    HANDLE hProcess;
+    DWORD_PTR processAffinityMask, systemAffinityMask;
+    
+    hProcess = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_SET_INFORMATION, 
+                          FALSE, processId);
+    if (hProcess == NULL) {
+        return FALSE;
+    }
+    
+    if (!GetProcessAffinityMask(hProcess, &processAffinityMask, &systemAffinityMask)) {
+        CloseHandle(hProcess);
+        return FALSE;
+    }
+    
+    DWORD_PTR newAffinityMask = coreInfo->pCoreMask & systemAffinityMask;
+    
+    if (newAffinityMask == 0) {
+        newAffinityMask = systemAffinityMask;
+    }
+    
+    BOOL result = SetProcessAffinityMask(hProcess, newAffinityMask);
+    CloseHandle(hProcess);
+    return result;
+}
+
+BOOL GetRealCoreInfo(CPUCoreInfo* coreInfo) {
+    DWORD bufferSize = 0;
+    PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX buffer = NULL;
+    BOOL result = FALSE;
+    
+    memset(coreInfo, 0, sizeof(CPUCoreInfo));
+    
+    if (!GetLogicalProcessorInformationEx(RelationProcessorCore, NULL, &bufferSize)) {
+        if (GetLastError() != ERROR_INSUFFICIENT_BUFFER) {
+            return FALSE;
+        }
+    }
+    
+    buffer = (PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX)malloc(bufferSize);
+    if (buffer == NULL) {
+        return FALSE;
+    }
+    
+    if (!GetLogicalProcessorInformationEx(RelationProcessorCore, buffer, &bufferSize)) {
+        free(buffer);
+        return FALSE;
+    }
+    
+    PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX current = buffer;
+    DWORD offset = 0;
+    
+    while (offset < bufferSize) {
+        if (current->Relationship == RelationProcessorCore) {
+            DWORD_PTR coreMask = current->Processor.GroupMask[0].Mask;
+            BYTE coreFlags = current->Processor.Flags;
+            
+            DWORD logicalProcessors = 0;
+            DWORD_PTR tempMask = coreMask;
+            while (tempMask) {
+                if (tempMask & 1) logicalProcessors++;
+                tempMask >>= 1;
+            }
+            
+            if (logicalProcessors >= 2) {
+                coreInfo->pCoreCount++;
+                coreInfo->pCoreMask |= coreMask;
+            } else {
+                coreInfo->eCoreCount++;
+                coreInfo->eCoreMask |= coreMask;
+            }
+            
+            coreInfo->totalCores++;
+        }
+        
+        offset += current->Size;
+        current = (PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX)((BYTE*)current + current->Size);
+    }
+    
+    coreInfo->isHybrid = (coreInfo->pCoreCount > 0 && coreInfo->eCoreCount > 0);
+    
+    if (coreInfo->totalCores == 0) {
+        SYSTEM_INFO sysInfo;
+        GetSystemInfo(&sysInfo);
+        DWORD totalLogicalProcessors = sysInfo.dwNumberOfProcessors;
+        
+        if (totalLogicalProcessors >= 8) {
+            DWORD halfCores = totalLogicalProcessors / 2;
+            
+            for (DWORD i = 0; i < halfCores; i++) {
+                coreInfo->pCoreMask |= ((DWORD_PTR)1 << i);
+            }
+            for (DWORD i = halfCores; i < totalLogicalProcessors; i++) {
+                coreInfo->eCoreMask |= ((DWORD_PTR)1 << i);
+            }
+            
+            coreInfo->pCoreCount = halfCores;
+            coreInfo->eCoreCount = totalLogicalProcessors - halfCores;
+            coreInfo->totalCores = totalLogicalProcessors;
+            coreInfo->isHybrid = TRUE;
+        }
+    }
+    
+    result = (coreInfo->totalCores > 0);
+    free(buffer);
+    return result;
+}
+
+BOOL IsIntelCPUWithECores() {
+    int cpuInfo[4];
+    char vendor[13];
+    
+    __cpuid(cpuInfo, 0);
+    memcpy(vendor, &cpuInfo[1], 4);
+    memcpy(vendor + 4, &cpuInfo[3], 4);
+    memcpy(vendor + 8, &cpuInfo[2], 4);
+    vendor[12] = '\0';
+    
+    if (strcmp(vendor, "GenuineIntel") != 0) {
+        return FALSE;
+    }
+    
+    __cpuid(cpuInfo, 1);
+    int family = ((cpuInfo[0] >> 8) & 0xF) + ((cpuInfo[0] >> 20) & 0xFF);
+    int model = ((cpuInfo[0] >> 4) & 0xF) | ((cpuInfo[0] & 0xF0000) >> 12);
+    
+    if (family == 6 && model >= 0x97) {
+        return TRUE;
+    }
+    
+    return FALSE;
 }


### PR DESCRIPTION
1. The start.game supports relative paths
2. Automatically disable e-cores of Intel processors.